### PR TITLE
Small updates to remove breakoutrooms

### DIFF
--- a/content/join.md
+++ b/content/join.md
@@ -25,6 +25,11 @@ anyone may attend the workshop.  With livestream attendance, you get:
 - A channel for questions (if you register)
 - To do exercises yourself, or in a self-organized group
 
+### Attend in a local event
+
+Some of our friends and partners arrange an on-site meetings where they follow the teaching
+together and get in-person assistance. Check the main workshop page to find local events near you. 
+
 
 ### Attend with own team
 
@@ -35,54 +40,59 @@ You can arrange everything with your friends and colleagues:
 - Agree where to meet
 - Agree how to follow the workshop
 - Maybe have some communications channel for your team
-- We send all registrants all information about the workshop
+- We send all registrantered participants information about the workshop
 - We don't need to know the details, but let us know if you have a team (for reporting purposes)
 
+These teams can consist of learners only, or they can have one or more people 
+who are familiar with the materials taught in our workshop. 
+We call them team leaders, please continue reading below.
 
-### Attend in a local partner's event
-
-Some of our partners arrange an on-site meetings where they follow the teaching
-together and get in-person assistance.  Feel free to suggest your educational
-institute to [become a
-partner](https://coderefinery.org/organization/partners/#joining-as-a-partner)
-and/or arrange a local breakout room.
-
-
-### Volunteer as team leader
+---
 
 CodeRefinery's mission is to enable everyone to use the computational
 tools they need for their work.  We do this by teaching the most important
 software development tools, which are often missed in other coursework.
-This is a big task, but together with our volunteer team leaders,
-we can do it.
+This is a big task, but together with you, we can do it:
 
-Volunteer to be an **team leader** at CodeRefinery, and you will:
+### Volunteer as a Q&A helper
+
+You'd like to help out during the workshop? 
+Join us answering questions from the participants in the Q&A document (collaborative notes).
+
+### Be a team leader
+
+If you step up and make yourself available as a **team leader** (for a team with your colleagues or in a local event) at CodeRefinery, and you will:
 - Mentor and provide positive encouragement for your team; guide them
   through the workshop.
-- Attend our quick team leader training (one hour, see schedule).
-- Have your own team (breakout room of ~5) during the course.
+- Attend our one hour onboarding session (see schedule).
+- Have your own team during the course.
 - Help keep the team on track.  You are the first line, but you don't
   need to know everything.
-- Call for other help when needed. We have the collaborative Q&A document for everyone.
+- Use the collaborative notes document to ask for support, when needed. 
 
 **Am I good enough to be a team leader?**  If you are asking this
 question, probably you are. If you have some familiarity with
 Git, you can provide some initial advice on obvious error messages,
-but the idea is that you are able to ask for advanced help when it's needed.
+but the idea is that you are able to ask for further help when it's needed.
 
-**You don't have to be located in the Nordics**. We welcome volunteers from
-institutions also outside the Nordics because volunteer team leaders help
+### Arrange your own local event
+
+Do you want to bring the CodeRefinery workshop to your community? 
+We are very happy for anyone who wants to organize local public events
+ to follow the workshop and provide own on-site support.
+If you want to support your local community,
+ you can arrange your own local event. This can be on-site or online.
+You can choose to arange your own registration or do the registration via us.  
+You and your potential team leaders will get onboarding from us (see schedule).
+
+
+**You don't have to be located in the Nordics**. We welcome teams and local events from
+anyone, also outside the Nordics. These satellite events or local classrooms help
 us to reach more people.
 
 {{ enddiv() }}
 
 {{ div() }}
-
-
-### Volunteer as a Q&A helper
-
-Being a team leader is too much work but you'd still like to help out during the workshop? 
-Join us while answering questions from the participants in the Q&A document (collaborative notes).
 
 
 ### Price and attendance priority policy
@@ -91,7 +101,8 @@ The course is free of charge, funded by the [Nordic e-Infrastructure
 Collaboration](https://neic.no/).  The livestream can scale up to an arbitrary
 number of viewers.  The local partners usually use "first come - first
 served"-principle + a waiting list.  Some might also accept only members of
-their own organisation.
+their own organisation. We do not have any influence on this. 
+But please know, that you can always follow the workshop on your own.
 
 
 ### Accessibility
@@ -100,19 +111,19 @@ We hope that everyone can attend and learn from this workshop, but we
 aren't perfect.  Our attempts are mentioned below, if you would like
 to help or there is something else we can do, please get in touch.
 
-* Breakout rooms with team leaders gives a community atmosphere
-  and private help, even in a big course.
-* Local partners can provide locally-relevant support, both short and
+* Teams provide a community atmosphere
+  and private help, even in a big streamed course.
+* Local events can provide locally-relevant support, both short and
   long term, without worrying about basic course mechanics.
 * Our material is provided in many different formats: writing (lesson
-  websites), by presenting, videos, Q&A, and more.
+  websites), by presenting, videos/recordings, Q&A, and more.
 * We record videos and post the notes so you can review at your own
   pace later on.  Videos completely preserve privacy (don't include
   audience voice or video).
 * Raw Twitch videos are available immediately - so you can immediately
   review anything you didn't catch the first time.  This greatly
   reduces pressure from the course.
-* We also try very hard to release YouTube videos by the same day, so
+* We also try to release YouTube videos by the same day, so
   that they are useful for further-refined instant review (even if
   they are not perfect).
 * A collaborative document allows everybody to ask questions anonymously and
@@ -126,7 +137,7 @@ to help or there is something else we can do, please get in touch.
 * You can follow along without providing any personal data
   (without registration to any services, though GitHub registration is
   used for many exercises).
-* We can share the course attendance with an unlimited number of
+* The course can be attended by an unlimited number of
   people.
 * Local sessions with partners and limited global interaction makes
   Code of Conduct monitoring much easier.

--- a/content/join.md
+++ b/content/join.md
@@ -40,7 +40,7 @@ You can arrange everything with your friends and colleagues:
 - Agree where to meet
 - Agree how to follow the workshop
 - Maybe have some communications channel for your team
-- We send all registrantered participants information about the workshop
+- We send all registered participants information about the workshop
 - We don't need to know the details, but let us know if you have a team (for reporting purposes)
 
 These teams can consist of learners only, or they can have one or more people 
@@ -82,7 +82,7 @@ We are very happy for anyone who wants to organize local public events
  to follow the workshop and provide own on-site support.
 If you want to support your local community,
  you can arrange your own local event. This can be on-site or online.
-You can choose to arange your own registration or do the registration via us.  
+You can choose to arrange your own registration or do the registration via us.  
 You and your potential team leaders will get onboarding from us (see schedule).
 
 


### PR DESCRIPTION
Please read carefully and continue editing where needed. 

Mainly wanted to remove mention of breakoutrooms and the like. 
And soften the "partner"- connection of local hosts to "anyone can do this". 

I tried to make the separation learner and "more" more clear, but not sure that succeeded.

Note that I did not preview locally (sorry, nothing set up here). 